### PR TITLE
Stub in bcReachabilityAnalyzer off ciMethod

### DIFF
--- a/src/hotspot/share/ci/bcReachabilityAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcReachabilityAnalyzer.cpp
@@ -1,0 +1,6 @@
+#include "ci/bcReachabilityAnalyzer.hpp"
+
+BCReachabilityAnalyzer::BCReachabilityAnalyzer(ciMethod* method, BCReachabilityAnalyzer* parent)
+{
+  // TODO
+}

--- a/src/hotspot/share/ci/bcReachabilityAnalyzer.hpp
+++ b/src/hotspot/share/ci/bcReachabilityAnalyzer.hpp
@@ -1,0 +1,13 @@
+#ifndef SHARE_CI_BCREACHABILITYANALYZER_HPP
+#define SHARE_CI_BCREACHABILITYANALYZER_HPP
+
+#include "ci/ciMethod.hpp"
+
+class BCReachabilityAnalyzer : public ResourceObj {
+
+ public:
+  BCReachabilityAnalyzer(ciMethod* method, BCReachabilityAnalyzer* parent = NULL);
+
+};
+
+#endif //SHARE_CI_BCREACHABILITYANALYZER_HPP

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -54,6 +54,9 @@
 #include "ci/ciTypeFlow.hpp"
 #include "oops/method.hpp"
 #endif
+// Static Analyzer
+#include "ci/bcReachabilityAnalyzer.hpp"
+
 
 // ciMethod
 //
@@ -100,6 +103,8 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
   _flow               = NULL;
   _bcea               = NULL;
 #endif // COMPILER2
+  // Static analzyer
+  _bcra               = NULL;
 
   ciEnv *env = CURRENT_ENV;
   if (env->jvmti_can_hotswap_or_post_breakpoint()) {
@@ -181,6 +186,9 @@ ciMethod::ciMethod(ciInstanceKlass* holder,
   _flow(                   NULL),
   _bcea(                   NULL)
 #endif // COMPILER2
+  //Static Analyzer
+  ,
+  _bcra(                    NULL)
 {
   // Usually holder and accessor are the same type but in some cases
   // the holder has the wrong class loader (e.g. invokedynamic call
@@ -1272,6 +1280,18 @@ BCEscapeAnalyzer  *ciMethod::get_bcea() {
     _bcea = new (CURRENT_ENV->arena()) BCEscapeAnalyzer(this, NULL);
   }
   return _bcea;
+#else // COMPILER2
+  ShouldNotReachHere();
+  return NULL;
+#endif // COMPILER2
+}
+
+BCReachabilityAnalyzer  *ciMethod::get_bcra() {
+#ifdef COMPILER2 //Static Analyzer
+  if (_bcra == NULL) {
+    _bcra = new (CURRENT_ENV->arena()) BCReachabilityAnalyzer(this, NULL);
+  }
+  return _bcra;
 #else // COMPILER2
   ShouldNotReachHere();
   return NULL;

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1287,15 +1287,16 @@ BCEscapeAnalyzer  *ciMethod::get_bcea() {
 }
 
 BCReachabilityAnalyzer  *ciMethod::get_bcra() {
-#ifdef COMPILER2 //Static Analyzer
+//Static Analyzer
   if (_bcra == NULL) {
     _bcra = new (CURRENT_ENV->arena()) BCReachabilityAnalyzer(this, NULL);
   }
   return _bcra;
-#else // COMPILER2
-  ShouldNotReachHere();
-  return NULL;
-#endif // COMPILER2
+// TODO: Introduce a proper define for the static analyzer and use this here
+// #else // Static Analyzer
+//   ShouldNotReachHere();
+//   return NULL;
+// #endif // Static Analyzer
 }
 
 ciMethodBlocks  *ciMethod::get_method_blocks() {

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -42,6 +42,7 @@ class Arena;
 class BCEscapeAnalyzer;
 class InlineTree;
 class xmlStream;
+class BCReachabilityAnalyzer;
 
 // Whether profiling found an oop to be always, never or sometimes
 // null
@@ -105,6 +106,8 @@ class ciMethod : public ciMetadata {
   ciTypeFlow*         _flow;
   BCEscapeAnalyzer*   _bcea;
 #endif
+  // Static analzyer
+  BCReachabilityAnalyzer* _bcra;
 
   ciMethod(const methodHandle& h_m, ciInstanceKlass* holder);
   ciMethod(ciInstanceKlass* holder, ciSymbol* name, ciSymbol* signature, ciInstanceKlass* accessor);
@@ -225,6 +228,9 @@ class ciMethod : public ciMetadata {
   }
   BCEscapeAnalyzer  *get_bcea();
   ciMethodBlocks    *get_method_blocks();
+  
+  // Static analzyer
+  BCReachabilityAnalyzer *get_bcra();
 
   bool    has_linenumber_table() const;          // length unknown until decompression
 


### PR DESCRIPTION
The reachabilityAnalyzer walks the ciBytecodeStream to find the
classes that need to be loaded and the methods to process next.

It should have a similar design to the bcEscapeAnalyzer.

Add stubs to ciMethod to be able to create one.  The rest of the
code for this will be pulled across from the StaticAnalyzer in
the djh/exploration branch

Signed-off-by: Dan Heidinga <heidinga@redhat.com>